### PR TITLE
Fixed allowed attributes for 'callout' mediator

### DIFF
--- a/mediators/core/callout.xsd
+++ b/mediators/core/callout.xsd
@@ -59,8 +59,10 @@
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
-            <xs:attribute name="serviceURL" type="xs:string" use="required"/>
+            <xs:attribute name="serviceURL" type="xs:string" use="optional"/>
             <xs:attribute name="action" type="xs:string" use="optional"/>
+            <xs:attribute name="initAxis2ClientOptions" type="xs:boolean" use="optional"/>
+            <xs:attribute name="endpointKey" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
- `serviceURL` is optional because it can be replaced with a `To` header
- added two other missing attributes